### PR TITLE
pc - update workflow 33 to publish stryker report even if coverage is below 100%

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 120
     env:
       destination: frontend/reports/mutation
 

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -71,21 +71,19 @@ jobs:
         if: always() # always upload artifacts, even if tests fail
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: stryker-incremental-${{ env.pr_number }}.json
-          path: frontend/history/stryker-incremental-${{ env.pr_number }}.json
+          name: stryker-incremental-${{env.pr_number}}.json
+          path: frontend/history/stryker-incremental-${{env.pr_number}}.json
 
       - name: Set path for github pages deploy when there is a PR num
         if: always() # always upload artifacts, even if tests fail
         run: |
-          if [[ "${{ env.pr_number }}" == "main" ]]; then
-            prefix=""
-            echo "prefix=${prefix}"
-            echo "prefix=${prefix}" >> "$GITHUB_ENV"
+          if [ "${{env.pr_number }}" = "main" ]; then
+             prefix=""
           else
-            prefix="prs/${pr_number}/"
-            echo "prefix=${prefix}"
-            echo "prefix=${prefix}" >> "$GITHUB_ENV"
+             prefix="prs/${{ env.pr_number }}/"
           fi
+          echo "prefix=${prefix}"
+          echo "prefix=${prefix}" >> "$GITHUB_ENV"
       
       - name: Deploy 🚀
         if: always() # always upload artifacts, even if tests fail


### PR DESCRIPTION
In this PR, we update workflow 33 so that even if the stryker report finds less than 100% coverage, the job will still push the report to Github Pages.

This will make it easier to see which mutants survived, and what new tests need to be written.