### PR TITLE
Change profile commons cards to display wealth and cows and compartmentalize commons card

### DIFF
--- a/frontend/src/main/components/Commons/CommonsCardBox.js
+++ b/frontend/src/main/components/Commons/CommonsCardBox.js
@@ -1,0 +1,63 @@
+import { useBackend } from "main/utils/useBackend";
+import React from "react";
+import { Card, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+const CommonsCardBox = ({ commons }) => {
+  const id = commons ? commons.id : -1;
+
+  // Stryker disable all
+  const commonsData = useBackend(
+    [`api/usercommons/forcurrentuser?commonsId=${id}`],
+    {
+      method: "GET",
+      url: '/api/usercommons/forcurrentuser',
+      params: {
+        commonsId: id,
+      }
+    }
+  );
+  // Stryker enable all
+
+  if (!commonsData || !commonsData.data || !commons) {
+    return null
+  }
+
+  return (
+    <Card
+      data-testid={"commons-card-box-" + id} style={
+        // Stryker disable all : no need to unit test CSS
+        {
+          width: '18rem',
+          margin: '0.3rem',
+          backgroundColor: 'white',
+          borderRadius: '0.5em',
+          boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
+        }
+        // Stryker enable all
+      }>
+      <Card.Body>
+        <Card.Title>{commons.name}</Card.Title>
+        <Card.Text style={
+          // Stryker disable next-line all : no need to unit test CSS
+          { margin: "0.2em" }
+        }>
+          Total wealth: ${commonsData.data.totalWealth}
+        </Card.Text>
+        <Card.Text>
+          Owned cows: {commonsData.data.numOfCows}
+        </Card.Text>
+        <Link to={"/play/" + id} data-testid={"enter-common-" + id} style={{
+          // Stryker disable next-line all : no need to unit test CSS
+          textDecoration: 'none'
+        }}>
+          <Button variant="primary">
+            Enter
+          </Button>
+        </Link>
+      </Card.Body>
+    </Card>
+  )
+};
+
+export default CommonsCardBox;

--- a/frontend/src/main/components/Commons/CommonsCardBox.js
+++ b/frontend/src/main/components/Commons/CommonsCardBox.js
@@ -3,6 +3,45 @@ import React from "react";
 import { Card, Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
+// This should only be used directly for stories. Otherwise use the default export.
+export function CommonsCardBoxWithData({ commons, userCommons }) {
+  return (
+    <Card
+      data-testid={"commons-card-box-" + commons.id} style={
+        // Stryker disable all : no need to unit test CSS
+        {
+          width: '18rem',
+          margin: '0.3rem',
+          backgroundColor: 'white',
+          borderRadius: '0.5em',
+          boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
+        }
+        // Stryker enable all
+      }>
+      <Card.Body>
+        <Card.Title>{commons.name}</Card.Title>
+        <Card.Text style={
+          // Stryker disable next-line all : no need to unit test CSS
+          { margin: "0.2em" }
+        }>
+          Total wealth: ${userCommons.data.totalWealth}
+        </Card.Text>
+        <Card.Text>
+          Owned cows: {userCommons.data.numOfCows}
+        </Card.Text>
+        <Link to={"/play/" + commons.id} data-testid={"enter-common-" + commons.id} style={{
+          // Stryker disable next-line all : no need to unit test CSS
+          textDecoration: 'none'
+        }}>
+          <Button variant="primary">
+            Enter
+          </Button>
+        </Link>
+      </Card.Body>
+    </Card>
+  )
+}
+
 const CommonsCardBox = ({ commons }) => {
   // Stryker disable all
   const id = commons ? commons.id : -1;
@@ -24,39 +63,7 @@ const CommonsCardBox = ({ commons }) => {
   }
 
   return (
-    <Card
-      data-testid={"commons-card-box-" + id} style={
-        // Stryker disable all : no need to unit test CSS
-        {
-          width: '18rem',
-          margin: '0.3rem',
-          backgroundColor: 'white',
-          borderRadius: '0.5em',
-          boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
-        }
-        // Stryker enable all
-      }>
-      <Card.Body>
-        <Card.Title>{commons.name}</Card.Title>
-        <Card.Text style={
-          // Stryker disable next-line all : no need to unit test CSS
-          { margin: "0.2em" }
-        }>
-          Total wealth: ${commonsData.data.totalWealth}
-        </Card.Text>
-        <Card.Text>
-          Owned cows: {commonsData.data.numOfCows}
-        </Card.Text>
-        <Link to={"/play/" + id} data-testid={"enter-common-" + id} style={{
-          // Stryker disable next-line all : no need to unit test CSS
-          textDecoration: 'none'
-        }}>
-          <Button variant="primary">
-            Enter
-          </Button>
-        </Link>
-      </Card.Body>
-    </Card>
+    <CommonsCardBoxWithData commons={commons} userCommons={commonsData} />
   )
 };
 

--- a/frontend/src/main/components/Commons/CommonsCardBox.js
+++ b/frontend/src/main/components/Commons/CommonsCardBox.js
@@ -24,10 +24,10 @@ export function CommonsCardBoxWithData({ commons, userCommons }) {
           // Stryker disable next-line all : no need to unit test CSS
           { margin: "0.2em" }
         }>
-          Total wealth: ${userCommons.data.totalWealth}
+          Total wealth: ${userCommons.totalWealth}
         </Card.Text>
         <Card.Text>
-          Owned cows: {userCommons.data.numOfCows}
+          Owned cows: {userCommons.numOfCows}
         </Card.Text>
         <Link to={"/play/" + commons.id} data-testid={"enter-common-" + commons.id} style={{
           // Stryker disable next-line all : no need to unit test CSS
@@ -45,8 +45,8 @@ export function CommonsCardBoxWithData({ commons, userCommons }) {
 const CommonsCardBox = ({ commons }) => {
   // Stryker disable all
   const id = commons ? commons.id : -1;
-  
-  const commonsData = useBackend(
+
+  const userCommons = useBackend(
     [`api/usercommons/forcurrentuser?commonsId=${id}`],
     {
       method: "GET",
@@ -58,12 +58,12 @@ const CommonsCardBox = ({ commons }) => {
   );
   // Stryker enable all
 
-  if (!commonsData || !commonsData.data || !commons) {
+  if (!userCommons || !userCommons.data || !commons) {
     return null
   }
 
   return (
-    <CommonsCardBoxWithData commons={commons} userCommons={commonsData} />
+    <CommonsCardBoxWithData commons={commons} userCommons={userCommons.data} />
   )
 };
 

--- a/frontend/src/main/components/Commons/CommonsCardBox.js
+++ b/frontend/src/main/components/Commons/CommonsCardBox.js
@@ -15,6 +15,7 @@ export function CommonsCardBoxWithData({ commons, userCommons }) {
           backgroundColor: 'white',
           borderRadius: '0.5em',
           boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
+          textAlign: 'center',
         }
         // Stryker enable all
       }>

--- a/frontend/src/main/components/Commons/CommonsCardBox.js
+++ b/frontend/src/main/components/Commons/CommonsCardBox.js
@@ -4,9 +4,9 @@ import { Card, Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
 const CommonsCardBox = ({ commons }) => {
-  const id = commons ? commons.id : -1;
-
   // Stryker disable all
+  const id = commons ? commons.id : -1;
+  
   const commonsData = useBackend(
     [`api/usercommons/forcurrentuser?commonsId=${id}`],
     {

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { Row, Col, Card, Button } from "react-bootstrap";
+import { Row, Col } from "react-bootstrap";
 import RoleBadge from "main/components/Profile/RoleBadge";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import ReactJson from "react-json-view";
-import { Link } from "react-router-dom";
+import CommonsCardBox from "main/components/Commons/CommonsCardBox";
 
 const ProfilePage = () => {
 
@@ -35,39 +35,11 @@ const ProfilePage = () => {
                     <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
                 </Col>
             </Row>
-            <Row className="align-items-center profile-header mb-5 text-center text-md-left">
-                {commons && commons.map((common) => (
-                    <Card key={common.id} style={
-                        // Stryker disable all : no need to unit test CSS
-                        {
-                            width: '18rem',
-                            margin: '0.3rem',
-                            backgroundColor: 'white',
-                            borderRadius: '0.5em',
-                            boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
-                        } 
-                        // Stryker enable all
-                    }>
-                        <Card.Body>
-                            <Card.Title>{common.name}</Card.Title>
-                            <Card.Text>
-                                Cow price: {common.cowPrice}
-                            </Card.Text>
-                            <Card.Text>
-                                Milk price: {common.milkPrice}
-                            </Card.Text>
-                            <Link to={"/play/" + common.id} data-testid={"enter-common-" + common.id} style={{
-                                // Stryker disable next-line all : no need to unit test CSS
-                                textDecoration: 'none'
-                            }}>
-                                <Button variant="primary">
-                                    Enter
-                                </Button>
-                            </Link>
-                        </Card.Body>
-                    </Card>
+            {commons && <Row className="align-items-center profile-header mb-5 text-center text-md-left">
+                {commons.map((common) => (
+                    <CommonsCardBox key={common.id} commons={common} />
                 ))}
-            </Row>
+            </Row>}
             <Row className="text-left">
                 <ReactJson src={currentUser.root} />
             </Row>

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -15,12 +15,4 @@ export const Default = Template.bind({});
 Default.args = {
   commons: userCommonsFixtures.oneUserCommons[0].commons,
   userCommons: userCommonsFixtures.oneUserCommons[0],
-}
-
-Default.decorators = [
-  (Story) => (
-    <div style={{ textAlign: 'center' }}>
-      <Story />
-    </div>
-  ),
-];
+};

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -4,7 +4,7 @@ import CommonsCardBox from "main/components/Commons/CommonsCardBox";
 import userCommonsFixtures from 'fixtures/userCommonsFixtures';
 
 export default {
-    title: 'pages/CommonsCardBox',
+    title: 'components/commons/CommonsCardBox',
     component: CommonsCardBox
 };
 

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -17,7 +17,7 @@ Default.args = {
   userCommons: userCommonsFixtures.oneUserCommons[0],
 }
 
-export const decorators = [
+Default.decorators = [
   (Story) => (
     <div style={{ textAlign: 'center' }}>
       <Story />

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -1,17 +1,18 @@
 import React from 'react';
 
-import CommonsCardBox from "main/components/Commons/CommonsCardBox";
+import { CommonsCardBoxWithData } from "main/components/Commons/CommonsCardBox";
 import userCommonsFixtures from 'fixtures/userCommonsFixtures';
 
 export default {
     title: 'components/commons/CommonsCardBox',
-    component: CommonsCardBox
+    component: CommonsCardBoxWithData
 };
 
-const Template = (props) => <CommonsCardBox {...props} />;
+const Template = (props) => <CommonsCardBoxWithData {...props} />;
 
 export const Default = Template.bind({});
 
 Default.args = {
     commons: userCommonsFixtures.oneUserCommons[0].commons,
+    userCommons: userCommonsFixtures.oneUserCommons[0],
 }

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import CommonsCardBox from "main/components/Commons/CommonsCardBox";
+import { userCommonsFixtures } from 'fixtures/userCommonsFixtures';
+
+export default {
+    title: 'pages/CommonsCardBox',
+    component: CommonsCardBox
+};
+
+const Template = (props) => <CommonsCardBox {...props} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+    commons: userCommonsFixtures.oneUserCommon[0].commons,
+}

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -13,5 +13,5 @@ const Template = (props) => <CommonsCardBox {...props} />;
 export const Default = Template.bind({});
 
 Default.args = {
-    commons: userCommonsFixtures.oneUserCommon[0].commons,
+    commons: userCommonsFixtures.oneUserCommons[0].commons,
 }

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import CommonsCardBox from "main/components/Commons/CommonsCardBox";
-import { userCommonsFixtures } from 'fixtures/userCommonsFixtures';
+import userCommonsFixtures from 'fixtures/userCommonsFixtures';
 
 export default {
     title: 'pages/CommonsCardBox',

--- a/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsCardBox.stories.js
@@ -4,8 +4,8 @@ import { CommonsCardBoxWithData } from "main/components/Commons/CommonsCardBox";
 import userCommonsFixtures from 'fixtures/userCommonsFixtures';
 
 export default {
-    title: 'components/commons/CommonsCardBox',
-    component: CommonsCardBoxWithData
+  title: 'components/commons/CommonsCardBox',
+  component: CommonsCardBoxWithData
 };
 
 const Template = (props) => <CommonsCardBoxWithData {...props} />;
@@ -13,6 +13,14 @@ const Template = (props) => <CommonsCardBoxWithData {...props} />;
 export const Default = Template.bind({});
 
 Default.args = {
-    commons: userCommonsFixtures.oneUserCommons[0].commons,
-    userCommons: userCommonsFixtures.oneUserCommons[0],
+  commons: userCommonsFixtures.oneUserCommons[0].commons,
+  userCommons: userCommonsFixtures.oneUserCommons[0],
 }
+
+export const decorators = [
+  (Story) => (
+    <div style={{ textAlign: 'center' }}>
+      <Story />
+    </div>
+  ),
+];

--- a/frontend/src/tests/components/Commons/CommonsCardBox.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCardBox.test.js
@@ -45,4 +45,15 @@ describe("CommonsCardBox tests", () => {
         expect(enterButton1).toBeInTheDocument();
         expect(enterButton1).toHaveAttribute('href', '/play/1')
     });
+
+    test("renders nothing when given invalid commons", async () => {
+        const { container } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CommonsCardBox />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
 });

--- a/frontend/src/tests/components/Commons/CommonsCardBox.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCardBox.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import CommonsCardBox from "main/components/Commons/CommonsCardBox";
+import userCommonsFixtures from "fixtures/userCommonsFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("CommonsCardBox tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+    const oneUserCommons = userCommonsFixtures.oneUserCommons[0];
+
+    beforeEach(() => {
+        axiosMock.onGet("/api/usercommons/forcurrentuser", {
+            params: { commonsId: oneUserCommons.id }
+        }).reply(200, oneUserCommons);
+    });
+
+    test("renders with correct data", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CommonsCardBox commons={oneUserCommons.commons} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(oneUserCommons.commons.name)).toBeInTheDocument();
+        expect(screen.getByTestId(`commons-card-box-${oneUserCommons.id}`)).toBeInTheDocument();
+        expect(screen.getByText(`Total wealth: $${oneUserCommons.totalWealth}`)).toBeInTheDocument();
+        expect(screen.getByText(`Owned cows: ${oneUserCommons.numOfCows}`)).toBeInTheDocument();
+    });
+
+    test("links button to correct commons", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CommonsCardBox commons={oneUserCommons.commons} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const enterButton1 = screen.getByTestId("enter-common-1");
+        expect(enterButton1).toBeInTheDocument();
+        expect(enterButton1).toHaveAttribute('href', '/play/1')
+    });
+});

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -7,16 +7,22 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import ProfilePage from "main/pages/ProfilePage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import userCommonsFixtures from "fixtures/userCommonsFixtures";
 
 describe("ProfilePage tests", () => {
     const queryClient = new QueryClient();
     const axiosMock = new AxiosMockAdapter(axios);
+    const oneUserCommons = userCommonsFixtures.oneUserCommons[0];
 
     beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+
+        axiosMock.onGet("/api/usercommons/forcurrentuser", {
+            params: { commonsId: oneUserCommons.id }
+        }).reply(200, oneUserCommons);
     });
 
     test("renders correctly for regular logged in user", async () => {
@@ -31,11 +37,7 @@ describe("ProfilePage tests", () => {
         expect(await screen.findByText("Phillip Conrad")).toBeInTheDocument();
         expect(screen.getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
         expect(screen.getByText("MyCommon")).toBeInTheDocument();
-        expect(screen.getByText("Cow price: 2")).toBeInTheDocument();
-        expect(screen.getByText("Milk price: 3")).toBeInTheDocument();
-
-        const enterButton1 = screen.getByTestId("enter-common-1");
-        expect(enterButton1).toHaveAttribute('href', '/play/1')
+        expect(screen.getByTestId(`commons-card-box-${oneUserCommons.id}`)).toBeInTheDocument();
     });
 
     test("renders correctly for admin user from UCSB", async () => {
@@ -55,10 +57,6 @@ describe("ProfilePage tests", () => {
         expect(screen.getByTestId("role-badge-member")).toBeInTheDocument();
         expect(screen.getByTestId("role-badge-admin")).toBeInTheDocument();
         expect(screen.getByText("MyCommon")).toBeInTheDocument();
-        expect(screen.getByText("Cow price: 2")).toBeInTheDocument();
-        expect(screen.getByText("Milk price: 3")).toBeInTheDocument();
-
-        const enterButton1 = screen.getByTestId("enter-common-1");
-        expect(enterButton1).toHaveAttribute('href', '/play/1')
+        expect(screen.getByTestId(`commons-card-box-${oneUserCommons.id}`)).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Closes #14. This also compartmentalizes the card into its own component so we can replace the commons cards in the front page with it in a future story.

Story
https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-2/prs/16/storybook/?path=/story/components-commons-commonscardbox--default

Before
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/51393127/8fdea160-b97f-492d-a2c3-d0d776643480)

After
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/51393127/8360d2f6-5468-4949-9cdd-69da3cf9d8bd)
