### PR TITLE
Added another variable of total cows bought with functionality

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,7 +7,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         }
     ],
     threeUserCommonsLB:
@@ -18,7 +19,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -26,7 +28,8 @@ const leaderboardFixtures = {
             "username": "two",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 8
         },
         {
             "id":3,
@@ -34,7 +37,8 @@ const leaderboardFixtures = {
             "username": "three",
             "commonsId": 1,
             "totalWealth" : 100000,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         }
     ],
     fiveUserCommonsLB: 
@@ -46,7 +50,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -55,7 +60,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         },
         {
             "id":3,
@@ -64,7 +70,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         },
         {
             "id":4,
@@ -73,7 +80,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":5,
@@ -81,7 +89,8 @@ const leaderboardFixtures = {
             "username": "five",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         }
     ],
     tenUserCommonsLB: 
@@ -93,7 +102,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -102,7 +112,8 @@ const leaderboardFixtures = {
             "username": "two",
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 8
         },
         {
             "id":3,
@@ -111,7 +122,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         },
         {
             "id":4,
@@ -120,7 +132,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":5,
@@ -129,7 +142,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         },
         {
             "id":6,
@@ -138,7 +152,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 8
         },
         {
             "id":7,
@@ -147,7 +162,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 8
         },
         {
             "id":8,
@@ -156,7 +172,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1000
         },
         {
             "id":9,
@@ -165,7 +182,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":10,
@@ -173,7 +191,8 @@ const leaderboardFixtures = {
             "username": "ten",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         }
     ]
 }

--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -8,7 +8,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         }
     ],
     threeUserCommonsLB:
@@ -20,7 +20,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -29,7 +29,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "numOfCows": 5,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":3,
@@ -38,7 +38,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         }
     ],
     fiveUserCommonsLB: 
@@ -51,7 +51,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -61,7 +61,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         },
         {
             "id":3,
@@ -71,7 +71,7 @@ const leaderboardFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         },
         {
             "id":4,
@@ -81,7 +81,7 @@ const leaderboardFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":5,
@@ -90,7 +90,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         }
     ],
     tenUserCommonsLB: 
@@ -103,7 +103,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -113,7 +113,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":3,
@@ -123,7 +123,7 @@ const leaderboardFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         },
         {
             "id":4,
@@ -133,7 +133,7 @@ const leaderboardFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":5,
@@ -143,7 +143,7 @@ const leaderboardFixtures = {
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         },
         {
             "id":6,
@@ -153,7 +153,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":7,
@@ -163,7 +163,7 @@ const leaderboardFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":8,
@@ -173,7 +173,7 @@ const leaderboardFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1000
+            "lifetimeNumCows": 1000
         },
         {
             "id":9,
@@ -183,7 +183,7 @@ const leaderboardFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":10,
@@ -192,7 +192,7 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -20,7 +20,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         }
     ],
     threeUserCommons:
@@ -44,7 +45,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -65,7 +67,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         },
         {
             "id":3,
@@ -86,7 +89,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         }
     ],
     fiveUserCommons: 
@@ -110,7 +114,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -131,7 +136,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         },
         {
             "id":3,
@@ -152,7 +158,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         },
         {
             "id":4,
@@ -173,7 +180,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":5,
@@ -194,7 +202,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         }
     ],
     tenUserCommons: 
@@ -218,7 +227,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 12
         },
         {
             "id":2,
@@ -239,7 +249,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 5
         },
         {
             "id":3,
@@ -260,7 +271,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1500
         },
         {
             "id":4,
@@ -281,7 +293,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":5,
@@ -302,7 +315,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         },
         {
             "id":6,
@@ -323,7 +337,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowsBought": 8
         },
         {
             "id":7,
@@ -344,7 +359,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowsBought": 8
         },
         {
             "id":8,
@@ -365,7 +381,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowsBought": 1000
         },
         {
             "id":9,
@@ -386,7 +403,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowsBought": 100
         },
         {
             "id":10,
@@ -407,7 +425,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowsBought": 60
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -21,7 +21,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         }
     ],
     threeUserCommons:
@@ -46,7 +46,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -68,7 +68,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         },
         {
             "id":3,
@@ -90,7 +90,7 @@ const userCommonsFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         }
     ],
     fiveUserCommons: 
@@ -115,7 +115,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -137,7 +137,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         },
         {
             "id":3,
@@ -159,7 +159,7 @@ const userCommonsFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         },
         {
             "id":4,
@@ -181,7 +181,7 @@ const userCommonsFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":5,
@@ -203,7 +203,7 @@ const userCommonsFixtures = {
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         }
     ],
     tenUserCommons: 
@@ -228,7 +228,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 12
+            "lifetimeNumCows": 12
         },
         {
             "id":2,
@@ -250,7 +250,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 5
+            "lifetimeNumCows": 5
         },
         {
             "id":3,
@@ -272,7 +272,7 @@ const userCommonsFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1500
+            "lifetimeNumCows": 1500
         },
         {
             "id":4,
@@ -294,7 +294,7 @@ const userCommonsFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":5,
@@ -316,7 +316,7 @@ const userCommonsFixtures = {
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         },
         {
             "id":6,
@@ -338,7 +338,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":7,
@@ -360,7 +360,7 @@ const userCommonsFixtures = {
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
-            "cowsBought": 8
+            "lifetimeNumCows": 8
         },
         {
             "id":8,
@@ -382,7 +382,7 @@ const userCommonsFixtures = {
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
-            "cowsBought": 1000
+            "lifetimeNumCows": 1000
         },
         {
             "id":9,
@@ -404,7 +404,7 @@ const userCommonsFixtures = {
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
-            "cowsBought": 100
+            "lifetimeNumCows": 100
         },
         {
             "id":10,
@@ -426,7 +426,7 @@ const userCommonsFixtures = {
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
-            "cowsBought": 60
+            "lifetimeNumCows": 60
         }
     ]
 }

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -12,6 +12,7 @@ const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
             {/* change $10 to info from fixture */}
             <Card.Title>Market Cow Price: ${commons?.cowPrice}</Card.Title>
             <Card.Title>Number of Cows: {userCommons.numOfCows}</Card.Title>
+            <Card.Title>Total Number of Cows Bought(Overall): {userCommons.cowsBought}</Card.Title>
                 <Row>
                     <Col>
                         <Card.Text>

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -12,7 +12,7 @@ const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
             {/* change $10 to info from fixture */}
             <Card.Title>Market Cow Price: ${commons?.cowPrice}</Card.Title>
             <Card.Title>Number of Cows: {userCommons.numOfCows}</Card.Title>
-            <Card.Title>Total Number of Cows Bought(Overall): {userCommons.cowsBought}</Card.Title>
+            <Card.Title>Total Number of Cows Bought(Overall): {userCommons.lifetimeNumCows}</Card.Title>
                 <Row>
                     <Col>
                         <Card.Text>

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -25,6 +25,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
         },
+        {
+            Header: 'Total Cows Bought',
+            accessor: 'cowsBought',
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -27,7 +27,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         },
         {
             Header: 'Total Cows Bought',
-            accessor: 'cowsBought',
+            accessor: 'lifetimeNumCows',
         },
     ];
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -66,7 +66,7 @@ describe("LeaderboardTable tests", () => {
     );
 
     const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Total Cows Bought'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'lifetimeNumCows'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Total Cows Bought'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowsBought'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,6 +190,7 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .cowsBought(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,7 +190,7 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
-        .cowsBought(0)
+        .lifetimeNumCows(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -90,6 +90,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
+          userCommons.setCowsBought(userCommons.getCowsBought()+1);
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -90,7 +90,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
-          userCommons.setCowsBought(userCommons.getCowsBought()+1);
+          userCommons.setLifetimeNumCows(userCommons.getLifetimeNumCows()+1);
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -33,5 +33,7 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
+
+  private int cowsBought;
 }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -34,6 +34,6 @@ public class UserCommons {
 
   private double cowHealth;
 
-  private int cowsBought;
+  private int lifetimeNumCows;
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100, 1);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })
@@ -148,6 +148,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -167,6 +168,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -177,6 +179,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -214,6 +217,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -233,6 +237,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -243,6 +248,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -280,6 +286,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -299,6 +306,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -309,6 +317,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
+      .cowsBought(1)    
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -346,6 +355,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -365,6 +375,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -375,6 +386,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -414,6 +426,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -434,6 +447,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -444,6 +458,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -484,6 +499,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -503,6 +519,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -513,6 +530,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -551,6 +569,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -570,6 +589,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -580,6 +600,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .cowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -623,6 +644,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -642,6 +664,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -652,6 +675,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .cowsBought(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -690,6 +714,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .cowsBought(0)
       .build();
   
       Commons testCommons = Commons
@@ -709,6 +734,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .cowsBought(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -719,6 +745,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .cowsBought(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -148,7 +148,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -168,7 +168,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -179,7 +179,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -217,7 +217,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -237,7 +237,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -248,7 +248,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -286,7 +286,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -306,7 +306,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -317,7 +317,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
-      .cowsBought(1)    
+      .lifetimeNumCows(1)    
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -355,7 +355,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -375,7 +375,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -386,7 +386,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -426,7 +426,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -447,7 +447,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -458,7 +458,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -499,7 +499,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -519,7 +519,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -530,7 +530,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -569,7 +569,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -589,7 +589,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -600,7 +600,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
-      .cowsBought(2)
+      .lifetimeNumCows(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -644,7 +644,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       Commons testCommons = Commons
@@ -664,7 +664,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -675,7 +675,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
-      .cowsBought(1)
+      .lifetimeNumCows(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -714,7 +714,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
-      .cowsBought(0)
+      .lifetimeNumCows(0)
       .build();
   
       Commons testCommons = Commons
@@ -734,7 +734,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
-      .cowsBought(0)
+      .lifetimeNumCows(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -745,7 +745,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
-      .cowsBought(0)
+      .lifetimeNumCows(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);


### PR DESCRIPTION
Closes [#4](https://github.com/orgs/ucsb-cs156-s23/projects/64?pane=issue&itemId=28963915) Added a cows bought variable that tracks the total amount of cows a user buys over the time the game is played. Helps the user track the amount of cows they ended up buying by the end of the game. (Note: the jpegs did not load in localhost, but I tested dokku qa and it worked there)

Before (Leaderboard)
<img width="1100" alt="BeforeLeaderboardHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/ba3d2b54-f1a6-4221-bb10-d65f3ea652c8">

After(Leaderboard)
<img width="1066" alt="AfterLeaderBoardHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/32d2fd37-b1e2-4e6a-8d50-8f0495cc189e">

Before(Play Page)
<img width="1251" alt="BeforePageHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/2b38e195-c18a-46f7-a3b4-cd43679c25e9">

After(Play Page)
<img width="1248" alt="AfterPageHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/d6a3850a-780b-48fe-86a9-6689d72bfdd1">

Before(Database)
<img width="521" alt="BeforeDBHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/3a70ff36-9343-4562-8b78-03ddd09ce4c8">

After(Database)
<img width="443" alt="AfterDBHC" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/6db059a9-315a-4164-b9ab-ef6e603595d1">

