### PR TITLE
Remove unnecessary state and effect from HomePage

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react"
 import { Container, Row, Col } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 
@@ -10,7 +9,6 @@ import Background from './../../assets/HomePageBackground.jpg';
 
 export default function HomePage() {
   // Stryker disable next-line all
-  const [commonsJoined, setCommonsJoined] = useState([]);
   const { data: currentUser } = useCurrentUser();
   // Stryker disable all 
 
@@ -37,21 +35,15 @@ export default function HomePage() {
     ["/api/currentUser"]
   );
 
-  useEffect(
-    () => {
-      if (currentUser?.root?.user?.commons) {
-        setCommonsJoined(currentUser.root.user.commons);
-      }
-    }, [currentUser]
-  );
-
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
+
+  const commonsJoined = currentUser?.root?.user?.commons || [];
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   let joinedIdList = [];
   for (let commonJoined of commonsJoined) {
-	joinedIdList.push(commonJoined.id)
+    joinedIdList.push(commonJoined.id)
   }
   let commonsNotJoined = commons.filter(f => !joinedIdList.includes(f.id));
 


### PR DESCRIPTION
This removes an unnecessary state and effect that's doing more harm than good. It causes out of sync state until the following render which can potentially be problematic for downstream consumers.

This does not change the UI visually.
https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-2/prs/19/storybook/?path=/story/pages-homepage--default-story