### PR TITLE
Changes userCommons and leaderboard Fixtures from PR17 & 25

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,7 +7,9 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         }
     ],
     threeUserCommonsLB:
@@ -18,7 +20,9 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 12,
+            "lifetimeCowsSold": 4
         },
         {
             "id":2,
@@ -26,7 +30,9 @@ const leaderboardFixtures = {
             "username": "two",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 3
         },
         {
             "id":3,
@@ -34,7 +40,9 @@ const leaderboardFixtures = {
             "username": "three",
             "commonsId": 1,
             "totalWealth" : 100000,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         }
     ],
     fiveUserCommonsLB: 
@@ -46,7 +54,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         },
         {
             "id":2,
@@ -55,7 +65,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         },
         {
             "id":3,
@@ -64,7 +76,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         },
         {
             "id":4,
@@ -73,7 +87,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":5,
@@ -81,7 +97,9 @@ const leaderboardFixtures = {
             "username": "five",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         }
     ],
     tenUserCommonsLB: 
@@ -93,7 +111,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 12,
+            "lifetimeCowsSold": 4
         },
         {
             "id":2,
@@ -102,7 +122,9 @@ const leaderboardFixtures = {
             "username": "two",
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 3
         },
         {
             "id":3,
@@ -111,7 +133,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         },
         {
             "id":4,
@@ -120,7 +144,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":5,
@@ -129,7 +155,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         },
         {
             "id":6,
@@ -138,7 +166,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 0
         },
         {
             "id":7,
@@ -147,7 +177,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 3
         },
         {
             "id":8,
@@ -156,7 +188,9 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1000,
+            "lifetimeCowsSold": 0
         },
         {
             "id":9,
@@ -165,7 +199,9 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":10,
@@ -173,7 +209,9 @@ const leaderboardFixtures = {
             "username": "ten",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -20,7 +20,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         }
     ],
     threeUserCommons:
@@ -44,7 +46,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 12,
+            "lifetimeCowsSold": 4
         },
         {
             "id":2,
@@ -65,7 +69,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         },
         {
             "id":3,
@@ -86,7 +92,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         }
     ],
     fiveUserCommons: 
@@ -110,7 +118,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 12,
+            "lifetimeCowsSold": 4
         },
         {
             "id":2,
@@ -131,7 +141,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         },
         {
             "id":3,
@@ -152,7 +164,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         },
         {
             "id":4,
@@ -173,7 +187,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":5,
@@ -194,7 +210,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         }
     ],
     tenUserCommons: 
@@ -218,7 +236,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 12,
+            "lifetimeCowsSold": 4
         },
         {
             "id":2,
@@ -239,7 +259,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 5,
+            "lifetimeCowsSold": 0
         },
         {
             "id":3,
@@ -260,7 +282,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1500,
+            "lifetimeCowsSold": 500
         },
         {
             "id":4,
@@ -281,7 +305,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":5,
@@ -302,7 +328,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         },
         {
             "id":6,
@@ -323,7 +351,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 0
         },
         {
             "id":7,
@@ -344,7 +374,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "lifetimeCowsBought": 8,
+            "lifetimeCowsSold": 3
         },
         {
             "id":8,
@@ -365,7 +397,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "lifetimeCowsBought": 1000,
+            "lifetimeCowsSold": 0
         },
         {
             "id":9,
@@ -386,7 +420,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "lifetimeCowsBought": 100,
+            "lifetimeCowsSold": 0
         },
         {
             "id":10,
@@ -407,7 +443,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "lifetimeCowsBought": 60,
+            "lifetimeCowsSold": 0
         }
     ]
 }


### PR DESCRIPTION
Changed both variable names to `lifetimeCowsBought` and `lifetimeCowsSold` in order to make the code clear for those reading it for the first time. Also changed some of the cows sold values in fixtures to make logical sense. 
I.E.) `numOfCows` = `lifetimeCowsBought` - `lifetimeCowsSold`

From PR#[17](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/pull/17) and #[25](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/pull/25)