### PR TITLE
Added Cows Sold and Bought Variables to UserCommons entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -33,5 +33,9 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
+
+  private int lifetimeCowsBought;
+
+  private int lifetimeCowsSold;
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100, 1, 0);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })


### PR DESCRIPTION
Added `lifetimeCowsBought` and `lifetimeCowsSold` to the UserCommons entity file to add them to the database. Also, modified one line of code in the UserCommonsController test as it would not compile unless I added values to a commons constructor. No functionality so there was no need to change more of the test file. 

Note: Please merge [PR#26](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/pull/26) first

Before (Database Table):
![Screen Shot 2023-06-02 at 1 54 17 PM](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/fe3d133f-b271-43ab-b921-cc458fb73210)

After (Database Table):
![Screen Shot 2023-06-02 at 2 13 42 PM](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/e0a5c485-3a5a-4c5c-b134-c4ff9b58e774)
