### PR TITLE
Added Functionality to cows sold and bought through UserCommonsController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -93,6 +93,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice()*numOfCowsToBuy ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice()*numOfCowsToBuy);
           userCommons.setNumOfCows(userCommons.getNumOfCows() +(numOfCowsToBuy));
+          userCommons.setLifetimeCowsBought(userCommons.getLifetimeCowsBought() + (numOfCowsToBuy));
         }
         else{
         throw new NotEnoughMoneyException("You need more money!");        }
@@ -120,6 +121,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getNumOfCows() >= 1 ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
+          userCommons.setLifetimeCowsSold(userCommons.getLifetimeCowsSold() + 1);
         }
         else{
           throw new NoCowsException("You have no cows to sell!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -33,5 +33,9 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
+
+  private int lifetimeCowsBought;
+
+  private int lifetimeCowsSold;
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -148,6 +148,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -167,6 +169,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -177,6 +181,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice()*2)
       .numOfCows(3)
       .cowHealth(100)
+      .lifetimeCowsBought(3)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -214,6 +220,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -233,6 +241,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -243,6 +253,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -281,6 +293,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -300,6 +314,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -310,6 +326,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -348,6 +366,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -367,6 +387,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -377,6 +399,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -414,6 +438,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -433,6 +459,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -443,6 +471,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -483,6 +513,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -503,6 +535,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -513,6 +547,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -553,6 +589,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -572,6 +610,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -582,6 +622,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -620,6 +662,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -639,6 +683,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -649,6 +695,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -688,6 +736,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -707,6 +757,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -717,6 +769,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .lifetimeCowsBought(2)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -750,6 +804,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -769,6 +825,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(00)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -779,6 +837,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -819,6 +879,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(20)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -838,6 +900,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(20)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -848,6 +912,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(20)
       .numOfCows(1)
       .cowHealth(100)
+      .lifetimeCowsBought(1)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -887,6 +953,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .lifetimeCowsBought(0)
+      .lifetimeCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -906,6 +974,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .lifetimeCowsBought(0)
+      .lifetimeCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -916,6 +986,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .lifetimeCowsBought(0)
+      .lifetimeCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100, 1, 0);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })


### PR DESCRIPTION
Modified userCommonsController and userCommonsController test to add functionality to `lifetimeCowsBought` and `lifetimeCowsSold` when buying and selling cows. An example using Swagger below to show that it works on the backend side.

Note: Please merge [PR#27](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/pull/27) first

When starting a new userCommons(numOfCows=0) and buying 3 cows:
<img width="1137" alt="Screen Shot 2023-06-02 at 4 07 27 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/529a0d2a-949a-499e-9343-6466384d68ca">

Then selling a cow:
<img width="1137" alt="Screen Shot 2023-06-02 at 4 08 07 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/6935b757-79b5-4213-aa2a-6dd599b4a0a1">

Then buying one cow:
<img width="1137" alt="Screen Shot 2023-06-02 at 4 10 12 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/114465206/31d7a29e-355b-4d86-996b-6b70b8322c3e">
