### PR TITLE
Fix image corruption on localhost

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
This fixes images that fallback to alt text on the backend localhost. The proxy controller could not handle binary data, leading to corrupted images. Validated no change in production.

Before
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/51393127/8d5bad06-168d-4f70-8b74-27563c45723c)

After
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/51393127/93c04f47-62a5-4736-b6fe-10268215a980)
