### PR TITLE
Add CowHerd entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowHerd.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowHerd.java
@@ -33,5 +33,5 @@ public class CowHerd {
     private int numCows;
 
     @Builder.Default
-    private int health = 100;
+    private double health = 100.0;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowHerd.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowHerd.java
@@ -1,0 +1,37 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+/**
+ * Represents the set of cows owned by a user that have the same health.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "cow_herd")
+public class CowHerd {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @EqualsAndHashCode.Exclude
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_commons_id")
+    private UserCommons userCommons;
+
+    private int numCows;
+
+    @Builder.Default
+    private int health = 100;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -1,6 +1,9 @@
 package edu.ucsb.cs156.happiercows.entities;
 
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -9,6 +12,8 @@ import lombok.AccessLevel;
 
 
 import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 @Data
 @AllArgsConstructor
@@ -30,6 +35,21 @@ public class UserCommons {
 
   private double totalWealth;
 
+  @EqualsAndHashCode.Exclude
+  @JsonManagedReference
+  @Builder.Default
+  @OneToMany(mappedBy = "userCommons", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private Set<CowHerd> cowHerds = new HashSet<CowHerd>();
+
+  public Set<CowHerd> getCowHerds() {
+    // Required for backwards compatibility
+    if (this.cowHerds == null) {
+      this.cowHerds = new HashSet<>();
+    }
+    return this.cowHerds;
+  }
+
+  // TODO: Remove once `cowHerds` is fully implemented
   private int numOfCows;
 
   private double cowHealth;

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowHerdRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowHerdRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.happiercows.entities.CowHerd;
+
+@Repository
+public interface CowHerdRepository extends CrudRepository<CowHerd, Long> {
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,15 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = UserCommons.builder()
+        .id(id)
+        .commonsId(1)
+        .userId(1)
+        .username("test")
+        .totalWealth(1)
+        .numOfCows(1)
+        .cowHealth(100)
+        .build();
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserCommonsTests.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class UserCommonsTests {
+    @Test
+    void getCowHerds_when_null() {
+        UserCommons userCommons = UserCommons.builder().cowHerds(null).build();
+        userCommons.setCowHerds(null);
+
+        Set<CowHerd> cowHerds = userCommons.getCowHerds();
+
+        assertNotNull(cowHerds);
+        assertEquals(0, cowHerds.size());
+    }
+
+    @Test
+    void getCowHerds_when_not_null() {
+        CowHerd cowHerd = CowHerd.builder().numCows(5).build();
+        UserCommons userCommons = new UserCommons();
+        userCommons.getCowHerds().add(cowHerd);
+
+        Set<CowHerd> cowHerds = userCommons.getCowHerds();
+
+        assertNotNull(cowHerds);
+        assertEquals(1, cowHerds.size());
+        assertEquals(cowHerd, cowHerds.iterator().next());
+    }
+}


### PR DESCRIPTION
Closes #33. This adds no user facing changes and as such, you must add/increment healthy herd to `/api/usercommons/buy` to test.
```java
Set<CowHerd> cowHerds = userCommons.getCowHerds();
Optional<CowHerd> fullHealthHerd = cowHerds.stream()
    .filter(herd -> herd.getHealth() == 100)
    .findFirst();
if (fullHealthHerd.isPresent()) {
    CowHerd healthyHerd = fullHealthHerd.get();
    healthyHerd.setNumCows(healthyHerd.getNumCows() + numOfCowsToBuy);
    cowHerdRepository.save(healthyHerd);
} else {
    CowHerd newHerd = CowHerd.builder()
        .numCows(numOfCowsToBuy)
        .userCommons(userCommons)
        .build();
    cowHerds.add(newHerd);
    cowHerdRepository.save(newHerd);
}
```

Each herd represents an integer health level. This ensures that the number of records scale with number of unique health levels rather than the number of cows.

## Partitioning
Previously, health levels can take any decimal number. When investigating the feasibility of various partitioning strategies, a few requirements must be considered.
* Decay formulas must still be able to be accurately applied. Partitions at too low of granularity would not be able to represent health decay well.
* It must be efficient to store and retrieve data, even with many users and cows. Storing cows at too high granularity poses a significant problem to memory usage.

### Hierarchical clustering

We can continue treating health as a double and apply the continuous decay formula. Then once the health of two herds come close (e.g., within 0.5%), merge the two herds. One of the biggest upside to this is that the decay formula is very precise. Herds will gain or lose health without jumping intervals. However, unless we display health with the maximum number of decimals that's possible, end users will see health jump intervals either way - even a UI change from 30% to 29.9% health does not fully represent the continuous changes cow health undergo.

This strategy poses another issue - let's assume we merge all herds that come within 0.5% health. Let's also assume we have a herd with 3 cows at 99.6% health and the user buys one new one at 100% health. By our clustering rule, we need to merge the 3 cows with the new one. There are four ways we can do this:
* Merge the herd with the higher health into the herd with the lower health
    * After merging, we'd have a herd with 4 cows at 99.6% health. However, the user just bought a completely brand new cow. Why does the user not own a cow at 100%? This is a UX issue - as a user, when I buy a completely brand new cow, I want to see that I gained a brand new cow. I don't want to see that it's instantly damaged. This gameplay dynamic is not only unsatisfactory as a player but can be very confusing for new players.
* Merge the herd with the lower health into the herd with the higher health
    * We can improve unsatisfactory purchase UX from the previous point by merging to the herd with the higher health value. However, this can be easily abused by instantly healing low health cows. If I have a herd with 10,000 cows at 99.6%, I can instantly bring them back to full health by buying a single new cow.
* Merge the two herds in the middle number
    * After the merge, the 4 cows would be at 99.8% health. However, this can still be abused if the number of cows are unbalanced.
* Calculate the average taking into account the number of cows in both herds
    * After the merge, the 4 cows would be at 99.7%. However, this has the same UX issue outlined in the 1st option.

We can see that all of the 4 merging strategies have an issue in either UX, gameplay fairness, or both.

### Binning

Instead of representing cows in a continuous spectrum, we can segment health into discrete intervals. To maintain backwards compatibility with the existing database, the existing cows will need to be rounded to the closest interval.

The main advantage to this strategy is that it's incredibly simple and straightforward in both gameplay and implementation. Players won't observe the strange gameplay dynamic where cow health levels maintain a continuous level of motion except when they don't depending on how close a herd is to another and health levels jump.

When considering the granularity of the intervals, it's a matter of balancing formula precision, memory consumption, and gameplay dynamic. If the interval is too coarse, we conserve memory but lose precision and UX. An interval that's too granular achieves the opposite effect.

### Result

I ended up binning at whole number intervals because that's ultimately what the end user will see. As a player, I want to deal with simple whole numbers when possible. I want to look at simple numbers like 34% rather than long numbers like 34.5%. Because of this, it makes sense that the number representation internally is the same. I chose to represent health levels as integers because at 100 possible values, decay formulas will likely be accurate enough. If there's a situation where percentages smaller than 1% is required, from a product perspective it's an indicator that the gameplay is more complex than necessary.

We also must validate the decay formula still works as expected. A possible side effect from this change is that small health changes less than 1 never commit, resulting in frozen health (e.g., 1% health might never get close enough to 0%).

![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-2/assets/51393127/f683cb0c-4cea-43f5-82f4-e55f9cc9db95)
