### PR TITLE
Cow death

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,7 +7,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 1
         }
     ],
     threeUserCommonsLB:
@@ -18,7 +19,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":2,
@@ -26,7 +28,8 @@ const leaderboardFixtures = {
             "username": "two",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 2
         },
         {
             "id":3,
@@ -34,7 +37,8 @@ const leaderboardFixtures = {
             "username": "three",
             "commonsId": 1,
             "totalWealth" : 100000,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 3
         }
     ],
     fiveUserCommonsLB: 
@@ -46,7 +50,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":2,
@@ -55,7 +60,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 2
         },
         {
             "id":3,
@@ -64,7 +70,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 3
         },
         {
             "id":4,
@@ -73,7 +80,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 4
         },
         {
             "id":5,
@@ -81,7 +89,8 @@ const leaderboardFixtures = {
             "username": "five",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 5
         }
     ],
     tenUserCommonsLB: 
@@ -93,7 +102,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":2,
@@ -102,7 +112,8 @@ const leaderboardFixtures = {
             "username": "two",
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 2
         },
         {
             "id":3,
@@ -111,7 +122,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 1
         },
         {
             "id":4,
@@ -120,7 +132,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 1
         },
         {
             "id":5,
@@ -129,7 +142,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 1
         },
         {
             "id":6,
@@ -138,7 +152,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":7,
@@ -147,7 +162,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 1
         },
         {
             "id":8,
@@ -156,7 +172,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 1
         },
         {
             "id":9,
@@ -165,7 +182,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 1
         },
         {
             "id":10,
@@ -173,7 +191,8 @@ const leaderboardFixtures = {
             "username": "ten",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 1
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -20,7 +20,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 2
         }
     ],
     threeUserCommons:
@@ -44,7 +45,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 2
         },
         {
             "id":2,
@@ -65,7 +67,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 2
         },
         {
             "id":3,
@@ -86,7 +89,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 2
         }
     ],
     fiveUserCommons: 
@@ -110,7 +114,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":2,
@@ -131,7 +136,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 1
         },
         {
             "id":3,
@@ -152,7 +158,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 1
         },
         {
             "id":4,
@@ -173,7 +180,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 1
         },
         {
             "id":5,
@@ -194,7 +202,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 1
         }
     ],
     tenUserCommons: 
@@ -218,7 +227,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":2,
@@ -239,7 +249,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 1
         },
         {
             "id":3,
@@ -260,7 +271,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 1
         },
         {
             "id":4,
@@ -281,7 +293,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 2
         },
         {
             "id":5,
@@ -302,7 +315,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 1
         },
         {
             "id":6,
@@ -323,7 +337,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "cowDeaths": 1
         },
         {
             "id":7,
@@ -344,7 +359,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "cowDeaths": 1
         },
         {
             "id":8,
@@ -365,7 +381,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "cowDeaths": 14
         },
         {
             "id":9,
@@ -386,7 +403,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "cowDeaths": 12
         },
         {
             "id":10,
@@ -407,7 +425,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "cowDeaths": 2
         }
     ]
 }

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -25,6 +25,7 @@ const ManageCows = ({ userCommons, commons, onBuy, onSell }) => {
       <Card.Body>
         <Card.Title>Market Cow Price: ${commons?.cowPrice}</Card.Title>
         <Card.Title>Number of Cows: {userCommons.numOfCows}</Card.Title>
+        <Card.Title>Cows Dead: {userCommons.cowDeaths}</Card.Title>
         <Row>
           <Col>
             <Card.Text>

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -25,6 +25,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
         },
+        {
+            Header: 'Cow Deaths',
+            accessor: 'cowDeaths'
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Cow Deaths'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'cowDeaths'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,6 +190,7 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .cowDeaths(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -33,5 +33,7 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
+
+  private int cowDeaths;
 }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -49,11 +49,12 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
                 ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
 
-                //Kills all cows when health = 0
-                if(newCowHealth <= 0){
+                //Kills all cows when health drops to 0
+                if(newCowHealth == 0 && userCommons.getCowHealth() != 0){
                     ctx.log("Cow health hit 0, and " + userCommons.getNumOfCows() + " cows died");
-                    userCommons.setCowDeaths(userCommons.getNumOfCows());
+                    userCommons.setCowDeaths(userCommons.getCowDeaths()+userCommons.getNumOfCows());
                     userCommons.setNumOfCows(0);
+                    //TODO currently resets cow health to 100 when cows die
                     userCommons.setCowHealth(100);
                 }
                 else{

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -48,7 +48,17 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
                 double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
                 ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
-                userCommons.setCowHealth(newCowHealth);
+
+                //Kills all cows when health = 0
+                if(newCowHealth <= 0){
+                    ctx.log("Cow health hit 0, and " + userCommons.getNumOfCows() + " cows died");
+                    userCommons.setCowDeaths(userCommons.getNumOfCows());
+                    userCommons.setNumOfCows(0);
+                    userCommons.setCowHealth(100);
+                }
+                else{
+                    userCommons.setCowHealth(newCowHealth);
+                }
                 userCommonsRepository.save(userCommons);
             }
         }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100, 0);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })


### PR DESCRIPTION
Adds cow death functionality when cow health hits zero.

If cow health hits 0 all a users cows die and a new stat cowDeaths is updated for the user. This stat can be viewed both from the users cow management tab and on the leaderboard.